### PR TITLE
Commit to keep extra condition or validation to check $n_archives is …

### DIFF
--- a/neuron_page.php
+++ b/neuron_page.php
@@ -727,7 +727,8 @@ $special_neuron_id_axo_axonic = result_set_to_array($result_special_case_axo_axo
 		<?php
 		  $hc2nmo->retrieve_archives_by_id($id);
 		  $n_archives = $hc2nmo->getN_archive();
-		  if ($n_archives > 0){
+		if (is_int($n_archives) && $n_archives > 0) {
+		 // if ($n_archives > 0){
 				print('
 					<table width="80%" border="0" cellspacing="2" cellpadding="0">
 						<tr>


### PR DESCRIPTION
…integer as, even when n_archives is 0 its not recognizing and not validating the > 0 condition

 and showing "List of Hippocampome.org to NeuroMorpho.Org mappings" when there are no "archives ie count is 0"

in the production or cng-hco-dev1, we commented out  if ($n_archives > 0){

but in next line we have { and the corresponding closing }., so I went ahead and kept the condition

 if (is_int($n_archives) && $n_archives > 0) { in line 731 and tested with 

https://hippocampome.org/php/neuron_page.php?id=1002
https://hippocampome.org/php/neuron_page.php?id=1000
https://hippocampome.org/php/neuron_page.php?id=1106